### PR TITLE
Add XmlEncode in NewImmediateTask function

### DIFF
--- a/SharpGPOAbuse/Program.cs
+++ b/SharpGPOAbuse/Program.cs
@@ -808,11 +808,30 @@ Revision=1";
             }
         }
 
+        public static string XmlEncode(string s)
+        {
+            if (!string.IsNullOrEmpty(s))
+            {
+                s = s.Replace("&", "&amp;");
+                s = s.Replace("'", "&apos;");
+                s = s.Replace("\"", "&quot;");
+                s = s.Replace(">", "&gt;");
+                s = s.Replace("<", "&lt;");
+            }
+            return s;
+        }
+
         public static void NewImmediateTask(String Domain, String DomainController, String GPOName, String distinguished_name, String task_name, String author, String arguments, String command, bool Force, String objectType)
         {
             string ImmediateTaskXML;
             string start = @"<?xml version=""1.0"" encoding=""utf-8""?><ScheduledTasks clsid=""{CC63F200-7309-4ba0-B154-A71CD118DBCC}"">";
             string end = @"</ScheduledTasks>";
+
+            author = XmlEncode(author);
+            task_name = XmlEncode(task_name);
+            command = XmlEncode(command);
+            arguments = XmlEncode(arguments);
+
             if (objectType.Equals("Computer"))
             {
                 ImmediateTaskXML = string.Format(@"<ImmediateTaskV2 clsid=""{{9756B581-76EC-4169-9AFC-0CA8D43ADB5F}}"" name=""{1}"" image=""0"" changed=""2019-03-30 23:04:20"" uid=""{4}""><Properties action=""C"" name=""{1}"" runAs=""NT AUTHORITY\System"" logonType=""S4U""><Task version=""1.3""><RegistrationInfo><Author>{0}</Author><Description></Description></RegistrationInfo><Principals><Principal id=""Author""><UserId>NT AUTHORITY\System</UserId><LogonType>S4U</LogonType><RunLevel>HighestAvailable</RunLevel></Principal></Principals><Settings><IdleSettings><Duration>PT10M</Duration><WaitTimeout>PT1H</WaitTimeout><StopOnIdleEnd>true</StopOnIdleEnd><RestartOnIdle>false</RestartOnIdle></IdleSettings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy><DisallowStartIfOnBatteries>true</DisallowStartIfOnBatteries><StopIfGoingOnBatteries>true</StopIfGoingOnBatteries><AllowHardTerminate>true</AllowHardTerminate><StartWhenAvailable>true</StartWhenAvailable><RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable><AllowStartOnDemand>true</AllowStartOnDemand><Enabled>true</Enabled><Hidden>false</Hidden><RunOnlyIfIdle>false</RunOnlyIfIdle><WakeToRun>false</WakeToRun><ExecutionTimeLimit>P3D</ExecutionTimeLimit><Priority>7</Priority><DeleteExpiredTaskAfter>PT0S</DeleteExpiredTaskAfter></Settings><Triggers><TimeTrigger><StartBoundary>%LocalTimeXmlEx%</StartBoundary><EndBoundary>%LocalTimeXmlEx%</EndBoundary><Enabled>true</Enabled></TimeTrigger></Triggers><Actions Context=""Author""><Exec><Command>{2}</Command><Arguments>{3}</Arguments></Exec></Actions></Task></Properties></ImmediateTaskV2>", author, task_name, command, arguments, Guid.NewGuid().ToString());


### PR DESCRIPTION
There is a bug in `NewImmediateTask` function

If the user set `Command` and `Arguments` as shown below, the character `>` will cause the `ScheduledTasks.xml`  to not be parsed correctly

```
--Command "cmd.exe" --Arguments "/c echo 1234 > %tmp%\1111.txt" 
```

This PR fixed this bug.