### PR TITLE
Fix XML corruption when creating scheduled tasks with --force flag

### DIFF
--- a/SharpGPOAbuse/Program.cs
+++ b/SharpGPOAbuse/Program.cs
@@ -899,7 +899,7 @@ Revision=1";
                         {
                             if (line.Replace(" ", "").Contains("</ScheduledTasks>"))
                             {
-                                line = ImmediateTaskXML + line;
+                                line = line.Replace("</ScheduledTasks>", ImmediateTaskXML + "</ScheduledTasks>");
                             }
                             new_list.Add(line);
                         }


### PR DESCRIPTION
I don't know if this project is maintained anymore, but I'll post it here in case anyone stumbles on it.

Currently, `SharpGPOAbuse`  corrupts the `ScheduledTasks.xml` file when overwriting or appending a task using the `--Force` flag. The bug happens on line 902:

`line = ImmediateTaskXML + line` 

This prepends the new task at the absolute beginning of the file, even before the `<?xml ...?>` header. This corrupts the  `ScheduledTasks.xml` file and causes an error on the client machines when fetching the new GPO. This is unfortunate, especially if you have only one GPO that you can take advantage of and don't want to run a scheduled task on all the machines linked to the GPO, meaning you are reliant on using the `--FilterEnabled` flag to filter for specific hosts and need to run the command multiple times.

The fix is simple, just add the `ImmediateTaskXML` inside the `<ScheduledTasks>` tag. Now you can add multiple scheduled tasks using the `--force` flag and even use the filtering to run different scheduled tasks on different targets. 